### PR TITLE
Use environment variable to enable subdirectory webroots

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,9 +2,9 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main", "drupal7", "drupal9" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "main", "drupal7", "drupal9" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
@@ -14,9 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Add branch name to environment
-      run: echo "BRANCH=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
     - name: Build image
       id: build
       uses: redhat-actions/buildah-build@v2.12
@@ -24,7 +21,7 @@ jobs:
         containerfiles: |
           ./Containerfile
         image: ${{ github.repository }}
-        tags: ${{ env.BRANCH }}
+        tags: latest
         # labels: # optional
 
     - name: Push To GHCR

--- a/Containerfile
+++ b/Containerfile
@@ -26,6 +26,7 @@ RUN apk add --no-cache \
 	bash \
 	curl \
 	geos \
+	gettext \
 	mariadb-client \
 	nginx \
 	openssh-client \
@@ -70,7 +71,7 @@ RUN apk add --no-cache \
 	rsync
 
 # Default nginx config
-COPY default.conf /etc/nginx/http.d/default.conf
+COPY default.template /etc/nginx/http.d/default.template
 COPY nginx.conf /etc/nginx/nginx.conf
 
 # Default php-fpm config

--- a/README.md
+++ b/README.md
@@ -2,5 +2,26 @@
 
 ![Docker Image CI](https://github.com/surreymagpie/nginx-php/actions/workflows/docker-image.yml/badge.svg)
 
-A lightweight container image based on Alpine Linux and providing the nginx web server with a php-fpm backend,
-and including PHP extensions commonly required by Drupal and Wordpress sites.
+A lightweight container image (~ 180MB) based on Alpine Linux and providing the
+nginx webserver with a php-fpm backend, and including PHP extensions commonly
+required by Drupal and Wordpress sites.
+
+If the web root resides in a subdirectory of your project (e.g. drupal 8/9/10
+projects using the `web` directory), pass the path through the `WEBROOT`
+environment variable as shown in the example below.
+
+The container image has been tested using `Podman` but should work just as well
+with `Docker`.
+
+```bash
+podman pull ghcr.io/surreymagpie/nginx-php:latest
+
+podman run \
+    --detach \
+    --publish 8080:80 \
+    --volume $(pwd):/var/www/html:Z \
+    --env=WEBROOT=my_subdir \
+    --name my-container \
+    ghcr.io/surreymagpie/nginx-php:latest
+```
+

--- a/default.conf
+++ b/default.conf
@@ -2,17 +2,26 @@ server {
         listen 80 default_server;
         listen [::]:80 default_server;
 
-        root /var/www/html;
+        root /var/www/html/web;
 
         index index.html index.php;
 
         server_name _;
 
+        # Block access to scripts in site files directory
+        location ~ ^/sites/[^/]+/files/.*\.php$ {
+                deny all;
+        }
+        
+        location ~ sites/default/files/.*php {
+                return 403;
+        }
+
         location / {
                 # First attempt to serve request as file, then
                 # as directory, then fall back to displaying a 404.
 
-                try_files $uri $uri/ =404;
+                try_files $uri $uri/ /index.php?$args;
 	}	
 
 	# pass PHP scripts to FastCGI server listening on 127.0.0.1:9000
@@ -22,4 +31,3 @@ server {
         }
 
 }
-

--- a/default.template
+++ b/default.template
@@ -2,7 +2,7 @@ server {
         listen 80 default_server;
         listen [::]:80 default_server;
 
-        root /var/www/html/web;
+        root $WEBROOT;
 
         index index.html index.php;
 

--- a/start.sh
+++ b/start.sh
@@ -1,10 +1,20 @@
-#!/bin/sh
+#!/bin/bash
 
-#Start php-fpm as root
+# Start php-fpm as root
 /usr/sbin/php-fpm82 -R
+
+# If WEBROOT variable is unset or empty, set the default root directory.
+# Otherwise append the subdirectory path to the default.
+if [[ ! -v WEBROOT ]] || [[ -z "$WEBROOT" ]]; then
+    export WEBROOT=/var/www/html
+else
+    export WEBROOT=/var/www/html/$WEBROOT
+fi
+
+# Use environment substitution to change the configuration file
+envsubst '$WEBROOT' < /etc/nginx/http.d/default.template > \
+    /etc/nginx/http.d/default.conf
 
 # Start nginx
 /usr/sbin/nginx -g 'daemon off;'
 
-# enable SSH
-eval $(ssh-agent)


### PR DESCRIPTION
Previously, two versions were required to accommodate different web root directories for Drupal 7 and later versions.

Using the environment variable allows greater flexibility while only requiring a single container image.