### PR TITLE
Add wordpress CLI

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -92,6 +92,11 @@ RUN wget https://github.com/drush-ops/drush/releases/download/8.4.12/drush.phar 
 	&& chmod +x drush.phar \
 	&& mv drush.phar /usr/local/bin/drush
 
+# Install Wordpress CLI
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
+	&& chmod +x wp-cli.phar \
+	&& mv wp-cli.phar /usr/local/bin/wp
+
 # Init script
 COPY start.sh /start.sh
 


### PR DESCRIPTION
Fixes #4

This commit adds the `wp` CLI for Wordpress into the container.

However as the user inside the container is root, there is a warning issued. The `--allow-root` option can be used to suppress this.

Further work may be possible to allow the CLI to run unprivileged inside the container without causing permission problems on the host.



