### PR TITLE
Change upload memory limits

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -98,11 +98,12 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 	&& mv wp-cli.phar /usr/local/bin/wp
 
 # Support Mailhog for email testing
-RUN sed -i 's/;sendmail_path =/sendmail_path = \/usr\/sbin\/sendmail -S mailhog:1025/' /etc/php83/php.ini 
-
 # Increase PHP memory to 256M
-RUN sed -i "s/^memory_limit\ =\ 128M/memory_limit\ =\ 256M/" /etc/php83/php.ini
-
+# Increase file upload size to 10MB
+RUN sed -i 's/;sendmail_path =/sendmail_path = \/usr\/sbin\/sendmail -S mailhog:1025/' /etc/php83/php.ini \
+  && sed -i "s/^memory_limit\ =\ 128M/memory_limit\ =\ 256M/" /etc/php83/php.ini \
+  && sed -i "s/^upload_max_filesize\ =\ 2M/upload_max_filesize\ =\ 10M/" /etc/php83/php.ini \
+  && sed -i "s/^post_max_size\ =\ 8M/post_max_size\ =\ 10M/" /etc/php83/php.ini
 # Init script
 COPY start.sh /start.sh
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -40,7 +40,7 @@ http {
 	# indicated by the request header Content-Length. If the stated content
 	# length is greater than this size, then the client receives the HTTP
 	# error code 413. Set to 0 to disable. Default is '1m'.
-	client_max_body_size 1m;
+	client_max_body_size 10m;
 
 	# Sendfile copies data between one FD and other from within the kernel,
 	# which is more efficient than read() + write(). Default is off.


### PR DESCRIPTION
Fixed #18

Changed `post_max_size` and `upload_max_filesize` in PHP and `client_max_body_size` in nginx, all to 10MB